### PR TITLE
Fix Docstring typo

### DIFF
--- a/scoretypes/GroupMinPrereq.py
+++ b/scoretypes/GroupMinPrereq.py
@@ -25,7 +25,7 @@ class GroupMinPrereq(ScoreTypeGroup):
     from prerequisites into a subtask/group/range.
 
     Parameters are [Display, [m, t, [p1, p2, ..., pi]], ... ]. prerequisite 
-    are *one-based* indexed. "Display" parameter must be either True or False,
+    are *one-based* indexed. "Display" parameter must be either true or false,
     which tells CMS whether to display the task outcome with prerequisite 
     testcases in the evaluation or not.
     """


### PR DESCRIPTION
https://github.com/Marszpace/cmsGroupMinPrereq/issues/1

This pull request includes a minor change to the `GroupMinPrereq` class in the `scoretypes/GroupMinPrereq.py` file. The change corrects the casing of the "Display" parameter description to align with Python's convention for boolean values, changing "True/False" to "true/false".